### PR TITLE
[14.0][FIX] subscription_oca: better partner form inheriting

### DIFF
--- a/subscription_oca/readme/CONTRIBUTORS.rst
+++ b/subscription_oca/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * `Ooops404 <https://www.ooops404.com>`__:
 
   * Ilyas <irazor147@gmail.com>
+  * Giovanni Serra <giovanni@gslab.it>

--- a/subscription_oca/views/res_partner_views.xml
+++ b/subscription_oca/views/res_partner_views.xml
@@ -4,7 +4,7 @@
     <record id="res_partner_view_form" model="ir.ui.view">
         <field name="name">res.partner.form</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="inherit_id" ref="account.partner_view_buttons" />
         <field name="arch" type="xml">
             <button name="action_view_partner_invoices" position="after">
                 <field name="subscription_ids" invisible="1" />


### PR DESCRIPTION
Fix an error raised for non admin user:


Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Impossibile localizzare l'elemento "<button name="action_view_partner_invoices">" nella vista principale

View name: res.partner.form
Error context:
 view: ir.ui.view(1843,)
 xmlid: subscription_oca.res_partner_view_form
 view.model: res.partner
 view.parent: ir.ui.view(118,)